### PR TITLE
RFC/Learning Remote Data Modelling

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -2,7 +2,7 @@ module Main exposing (Model, Msg(..), init, main, subscriptions, update, view, v
 
 import Browser
 import FeatherIcons
-import Html exposing (Html, br, button, div, footer, h1, h2, li, span, text, ul)
+import Html exposing (Html, br, button, div, footer, h1, h2, li, main_, span, text, ul)
 import Html.A11y exposing (ariaHidden, ariaLabel, ariaPressed, focusable)
 import Html.Attributes exposing (attribute, class)
 import Html.Events exposing (onClick)
@@ -61,7 +61,7 @@ update msg model =
 view : Model -> Html Msg
 view model =
     div [ class ("container color-fg " ++ Theme.toClass model.theme) ]
-        [ div [ class "main" ]
+        [ main_ [ class "main" ]
             [ div []
                 [ h1 [] [ text "Onko metro rikki?" ]
                 , viewStatusRequest model.statusRequest

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -54,6 +54,10 @@ update msg model =
             ( { model | theme = newTheme }, Cmd.none )
 
 
+
+-- VIEW
+
+
 view : Model -> Html Msg
 view model =
     div [ class ("container " ++ Theme.toClass model.theme) ]
@@ -161,9 +165,17 @@ viewFooter =
 """
 
 
+
+-- SUBSCRIPTIONS
+
+
 subscriptions : Model -> Sub Msg
 subscriptions model =
     Sub.none
+
+
+
+-- MAIN
 
 
 main : Program () Model Msg

--- a/src/Status.elm
+++ b/src/Status.elm
@@ -1,0 +1,131 @@
+module Status exposing (Status(..), StatusRequest(..), get, requestHandler)
+
+import Http
+import Json.Decode as JD exposing (Decoder)
+import Json.Decode.Pipeline as JP
+
+
+
+-- TYPES
+
+
+{-| Represents how the request for a status is progressing
+TODO: Consider "Refreshing" if implemented
+-}
+type StatusRequest
+    = NotAsked
+    | Loading
+    | Success Status
+    | Error String
+
+
+{-| The concrete status
+TODO: Figure out what {error: Maybe String} means
+Instead of "Success" and "Broken", we say "Working" and "Broken",
+which match the domain.
+We could even say "NotBroken", if it matches better, though double
+negatives are usually less comprehensible.
+-}
+type Status
+    = Working
+      --NOTE: Presumably "List String" is NonEmpty? Or could it be empty?
+      -- Could also consider a special case for empty reasons,
+      -- such as "Reason not known", and even encode that in the type
+    | Broken (List String)
+
+
+
+-- JSON
+
+
+{-| Boolean flags can quickly make the domain a mess.
+The real question, though, is how to deal with them.
+We cannot change the backend atm.
+
+Two possible ways to do this:
+
+  - Decode straight to StatusRequest
+  - Decode to an alias that describes the shape of the JSON technically,
+    and then translate that into the StatusRequest
+
+-}
+type alias StatusRequestDTO =
+    { success : Bool
+    , broken : Bool
+    , reasons : List String
+    , error : Maybe String
+    }
+
+
+{-| Decode the request to get status.
+
+    There are many ways to do this, some including more Json.Decode-fu than others.
+    To make it simpler, we decode straight to a Data Transfer Object (DTO), which
+    matches the API, and then write the StatusRequestDTO -> StatusRequest function
+
+    e.g.
+        JD.decode requestDecoder {error: "Something"} === Error "Something"
+        JD.decode requestDecoder {success: true} === Success Working
+        JD.decode requestDecoder {broken: true} === Success Broken
+
+-}
+requestDecoder : Decoder StatusRequest
+requestDecoder =
+    (JD.succeed
+        StatusRequestDTO
+        |> JP.required "success" JD.bool
+        |> JP.required "broken" JD.bool
+        |> JP.required "reasons" (JD.list JD.string)
+        |> JP.optional "error" (JD.maybe JD.string) Nothing
+    )
+        |> JD.map dtoToStatusRequest
+
+
+{-| Wrap the boolean flags into a nice StatusRequest
+TODO: Validate the order and semantics of these with Olavi
+-}
+dtoToStatusRequest : StatusRequestDTO -> StatusRequest
+dtoToStatusRequest { success, broken, reasons, error } =
+    case error of
+        Just err ->
+            Error err
+
+        Nothing ->
+            case broken of
+                True ->
+                    Success (Broken reasons)
+
+                False ->
+                    case success of
+                        True ->
+                            Success Working
+
+                        False ->
+                            Error "Metro is neither working nor broken"
+
+
+
+-- HTTP
+
+
+get : Http.Request StatusRequest
+get =
+    Http.get "https://api.onkometrorikki.fi/isitbroken" requestDecoder
+
+
+{-| Transform the HTTP Result into a StatusRequest, and convert to some message type
+-}
+requestHandler toMsg =
+    toMsg << resultToStatusRequest
+
+
+{-| Transform the HTTP Result into a StatusRequest
+-}
+resultToStatusRequest : Result Http.Error StatusRequest -> StatusRequest
+resultToStatusRequest result =
+    case result of
+        Ok statusRequest ->
+            statusRequest
+
+        Err error ->
+            Error "Virhe pyynnön lähettämisessä"


### PR DESCRIPTION
Hello! This is less of a PR and more of a "here's how I would structure this", based of our chat last Friday.
I really like this project, because it is small, and yet can demonstrate the way one can model and refactor Elm programs.

## Remote Data
Remote data, in particular, is super fun to model, and can elminate a class of errors or impossible states in the application.

For example, the response from the API is:

```elm
{
  success: Bool,
  broken: Bool,
  error: Bool,
  reasons: List String
}
```

This does not necessarily represent the model. Does "success" mean that the metro is working or that the results went well? Does broken matter only if it is broken, and is `broken: false` an indication that it is working? Do reasons appear only when broken, or do they also give reasons for the mero working? Similarly for `error`, is it a backend error etc. Of course, I am exaggerating, because by looking at the views and knowing some bits about the domain, we can definitely "know" what these mean. I think the code representing this is even cooler, because then the views are sort of just derived :)

Modelling the loading states explicitly also allows us to extend them, for example to add a `Refreshing Status` variant, where you serve the stale status, and maybe a message.

## Booleans and other states

I find that "rolling out" the booleans as a table helps a lot in deciding what the states of the model are.
In this case, I ended up with `type Status = Working | Broken (List String)`, trying to get more of the domain terminology in.

## (Json) Decoding

This also plays into Json decoding being "mandatory".
It encourages making these transforms more prominent, since you are deserialising anyway.
Note that in this case, I have **not** used the Json decoders to do the `Json.Value -> Status` directly. Instead, I convert to a "simple" Elm representation, and use normal functions, since I find it easier to read.

## Modules

One of the "not obvious" good parts of Elm is the module system.
It allows you to write simpler functions inside the module, expose only certain parts (types that you want to match on? types that you want to not be constructable?), and in general focus on the *data*, and functions relating to it.

I really like it at the call site as well, because it namespaces everything, makes autocomplete nicer, and so on.

```elm
import Theme exposing (Theme)
import Status exposing (Status)

-- I often do this
import Html as H
import Html.Attributes as HA
import Html.Events as HE

-- Later on
inverted = Theme.invert myTheme

viewStatus status =
  case status of
       Loading -> H.span [HA.class "loading"] [ text "loading ]
       -- etc
```

Conversely, in JS, I find myself writing functions like this:

```js
export const getUserName = (user) => { ... }
export const getUserId = (user) => { ... }
export const encodeUser = (user) => {...}
```

...because they will be used as named imports `import {encodeUser} from '..."` 90% of the time.

The `import * as User from 'user` pattern would allow you to write `User.encode(user)` instead, but I suspect that people avoid it for a few reasons: 
- It seems more verbose?
- Python uses "*" to mean "import everything", whereas in ES modules it is a namespace
- Funky tree-shaking myths
- People do not write CapitalCase, usually reserving it for classes
- etc.

But point is, in Elm it is a good way of taming things, and I am a fan.
I avoid putting too many "views" in these "data modules", but I do add decoding, HTTP requests (though one could have those in some other place, like `Api.elm` if it makes sense) etc.

## Wrapping up
I felt like writing things :grinning: