### PR TITLE
Avoid tweeting fixed metro too eagerly

### DIFF
--- a/backend/bot.js
+++ b/backend/bot.js
@@ -98,7 +98,12 @@ const shouldTweetNow = async brokenNow =>
       new Date() - previousTweetTime > config.twitterConfig.minInterval
     ) {
       resolve(true);
-    } else if (previouslyWasBroken === true && brokenNow === false) {
+    } else if (
+      previouslyWasBroken === true &&
+      brokenNow === false &&
+      previousTweetTime !== null &&
+      new Date() - previousTweetTime > config.twitterConfig.minInterval
+    ) {
       resolve(true);
     } else {
       resolve(false);


### PR DESCRIPTION
This should fix the issue of tweeting the "Metro works again" tweet too eagerly