### PR TITLE
Improvement/A11y: Refresh button semantics

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -56,6 +56,7 @@ type Msg
     | Refresh Time.Posix
     | UpdateTime Time.Posix
     | AdjustTimeZone Time.Zone
+    | NoOp
 
 
 
@@ -83,6 +84,9 @@ update msg model =
             ( { model | zone = newZone }
             , Task.perform Refresh Time.now
             )
+
+        NoOp ->
+            ( model, Cmd.none )
 
 
 
@@ -204,8 +208,7 @@ viewRefreshButton statusRequest theme =
                     False
     in
     button
-        [ disabled isRefreshing
-        , class "button-reset refresh-button enhanced-outline"
+        [ class "button-reset refresh-button enhanced-outline"
         , class
             (if isRefreshing then
                 "refreshing"
@@ -213,10 +216,17 @@ viewRefreshButton statusRequest theme =
              else
                 ""
             )
-
-        -- Show this button also with inverted colors
         , class (Theme.toClass (Theme.invert theme))
-        , onClick (Refresh (Time.millisToPosix 0))
+
+        -- Instead of disabling the button, remove the onClick handler when submitting
+        , onClick
+            (case isRefreshing of
+                True ->
+                    NoOp
+
+                False ->
+                    Refresh (Time.millisToPosix 0)
+            )
         ]
         [ span [ class "refresh-button-label" ] [ text "Refresh" ]
         , FeatherIcons.refreshCw

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -228,7 +228,7 @@ viewRefreshButton statusRequest theme =
                     Refresh (Time.millisToPosix 0)
             )
         ]
-        [ span [ class "refresh-button-label" ] [ text "Refresh" ]
+        [ span [ class "refresh-button-label" ] [ text "Päivitä" ]
         , FeatherIcons.refreshCw
             |> FeatherIcons.toHtml [ ariaHidden True, focusable False ]
         ]

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -204,9 +204,7 @@ viewRefreshButton statusRequest theme =
                     False
     in
     button
-        [ ariaPressed isRefreshing
-        , ariaLabel "Refresh"
-        , disabled isRefreshing
+        [ disabled isRefreshing
         , class "button-reset refresh-button enhanced-outline"
         , class
             (if isRefreshing then
@@ -220,7 +218,8 @@ viewRefreshButton statusRequest theme =
         , class (Theme.toClass (Theme.invert theme))
         , onClick (Refresh (Time.millisToPosix 0))
         ]
-        [ FeatherIcons.refreshCw
+        [ span [ class "refresh-button-label" ] [ text "Refresh" ]
+        , FeatherIcons.refreshCw
             |> FeatherIcons.toHtml [ ariaHidden True, focusable False ]
         ]
 

--- a/src/main.css
+++ b/src/main.css
@@ -176,12 +176,20 @@ footer ul li {
   box-shadow: 0 0 0 4px var(--color-accent);
 }
 
+/** Refresh button */
 @keyframes spin {
   100% {
     transform: rotate(360deg);
   }
 }
 
+.refresh-button-label {
+  margin-right: 0.5rem;
+}
+
 .refresh-button.refreshing > svg {
   animation: spin 1s linear infinite;
+
+  /* Only start the animation after a small interval */
+  animation-delay: 400ms;
 }


### PR DESCRIPTION
A rather out-of-the-blue PR, sorry about that.
I was looking at the refresh button - great feature, especially if one is worrying about having recent info!

I noticed a couple of things:
Unlike the "dark mode on" "dark mode off", toggle button, this one does not toggle anything. It performs an action instead. Thus, the `ariaPressed` is not needed, and can be a bit confusing for users.

[Disabling buttons is typically not great](https://axesslab.com/disabled-buttons-suck/).
This is especially true for forms. The intent behind disabling them is to prevent the user from mashing the button and submitting/refreshing more than once in a row. But setting `disabled` also takes the button out of focus order. 

For "do this action" buttons, like the refresh here, I think it's more of an open question. I opted to just set the click handler to a `NoOp` if the request is refreshing, instead of disabling. I think it's a safer bet. I would love to ask around some folks as an exercise, and see what they think.

I also added an explicit "Refresh" button text. I was not sure what the button did when I pressed on it myself, and when the refresh time is so fast, it took me a few clicks! It looks a bit more like an action now, as opposed to the night mode "setting". Definitely the smallest of the changes though, so go with your gut feeling :)

Finally, for some overkill UX stuff, I added an `animation-delay` to the spinner. When the refresh time is fast, it looked weird that it starts spinning like 5% and then snaps to the beginning. So no the animation won't start at all if the refresh is fast (the text up top still flashes and changes, which is probably enough to communicate that something happened).

**Tl;dr**
A couple of changes to the button semantics to make it an action instead of a toggle. Some minor UX things. A PR description longer than the PR itself :grimacing: 