### PR TITLE
now v2 ready

### DIFF
--- a/.nowignore
+++ b/.nowignore
@@ -1,0 +1,3 @@
+node_modules
+build
+backend

--- a/now.json
+++ b/now.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "public": true,
   "name": "onkometrorikki",
   "alias": [
     "onkometrorikki.fi",
@@ -6,5 +8,7 @@
     "onkometrorikki.now.sh",
     "onkolansimetrorikki.now.sh"
   ],
-  "type": "static"
+  "builds": [
+    {"src": "package.json", "use": "@now/static-build", "config": {"distDir": "build"}}
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "frontend": "elm-app start",
     "backend": "node ./backend/index.js",
     "build": "NODE_ENV=production elm-app build",
+    "now-build": "NODE_ENV=production elm-app build",
     "deploy:now": "now --public ./build --local-config=../now.json && now alias --local-config=./now.json",
     "release": "npm run build && npm run deploy:now",
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
This PR makes your frontend ready for Now V2.
I would also recommend that you deploy your backend to v2, if you want to.
Another recommendation would be to convert this into a monorepo approach, like:
https://github.com/paulogdm/chop-my-url
or https://github.com/paulogdm/s3-example
(for example).