### PR TITLE
Configure Travis CI and introduce first test

### DIFF
--- a/.nowignore
+++ b/.nowignore
@@ -1,3 +1,4 @@
 node_modules
 build
 backend
+tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: elm
+elm:
+  - '0.19.0'

--- a/elm.json
+++ b/elm.json
@@ -23,7 +23,11 @@
         }
     },
     "test-dependencies": {
-        "direct": {},
-        "indirect": {}
+        "direct": {
+            "elm-explorations/test": "1.2.0"
+        },
+        "indirect": {
+            "elm/random": "1.0.0"
+        }
     }
 }

--- a/tests/ViewStatusTest.elm
+++ b/tests/ViewStatusTest.elm
@@ -1,0 +1,36 @@
+module ViewStatusTest exposing (statusFuzzer, suite)
+
+import Expect exposing (Expectation)
+import Fuzz exposing (Fuzzer, int, list, string)
+import Main
+import Status exposing (Status(..))
+import Test exposing (..)
+import Test.Html.Query as Query
+import Test.Html.Selector as Selector
+import Time
+
+
+suite : Test
+suite =
+    fuzz statusFuzzer "viewStatus should show correct option" <|
+        \status ->
+            Main.viewStatus status (Time.millisToPosix 0) Time.utc
+                |> Query.fromHtml
+                |> Query.find [ Selector.tag "h2" ]
+                |> Query.has
+                    (case status of
+                        Working ->
+                            [ Selector.text "Ei" ]
+
+                        Broken reasons ->
+                            [ Selector.text "Kyllä" ]
+                    )
+
+
+statusFuzzer : Fuzzer Status
+statusFuzzer =
+    Fuzz.oneOf
+        [ Fuzz.list Fuzz.string
+            |> Fuzz.map Broken
+        , Fuzz.constant Working
+        ]


### PR DESCRIPTION
Here's a starting point for testing your program. A Travis CI configuration is included. 

I didn't want to go overboard with too many tests with this PR, but I added a simple view test for the core of the service: `Main.viewStatus`. The test is done using a `Fuzzer Status`, which means the tests run against a large number of randomized statuses automatically.